### PR TITLE
Fix test suite's logback.xml to write to a logfile

### DIFF
--- a/components/test-suite/logback-target-test-runner.xml
+++ b/components/test-suite/logback-target-test-runner.xml
@@ -3,13 +3,13 @@
   <appender name="performance" class="loci.tests.testng.TimestampedLogFileAppender">
     <File>target-test-runner-performance.log</File>
     <layout class="ch.qos.logback.classic.PatternLayout">
-      <pattern>%d %-10.10r [%10.10t] %-6.6p %40.40c %x - %m</pattern>
+      <pattern>%d %-10.10r [%10.10t] %-6.6p %40.40c %x - %m%n</pattern>
     </layout>
   </appender>
   <appender name="default" class="loci.tests.testng.TimestampedLogFileAppender">
     <File>target-test-runner.log</File>
     <layout class="ch.qos.logback.classic.PatternLayout">
-      <pattern>%d %-10.10r [%10.10t] %-6.6p %40.40c %x - %m</pattern>
+      <pattern>%d %-10.10r [%10.10t] %-6.6p %40.40c %x - %m%n</pattern>
     </layout>
   </appender>
   <logger name="org.perf4j" level="info">

--- a/components/test-suite/logback.xml
+++ b/components/test-suite/logback.xml
@@ -5,7 +5,14 @@
       <pattern>[%d] [%t] %m%n</pattern>
     </encoder>
   </appender>
+  <appender name="logfile" class="loci.tests.testng.TimestampedLogFileAppender">
+    <File>bio-formats-test.log</File>
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <pattern>[%d] [%t] %m%n</pattern>
+    </layout>
+  </appender>
   <root level="INFO">
     <appender-ref ref="stdout"/>
+    <appender-ref ref="logfile"/>
   </root>
 </configuration>


### PR DESCRIPTION
8ce8dbe removed the ability to log automated data test output to a file.  This restores that feature using `logback.xml` instead of hard-coded file creation in `loci.tests.testng.TestTools`.
