### PR TITLE
Colorizer fixes

### DIFF
--- a/components/formats-api/src/loci/formats/BytesWrapper.java
+++ b/components/formats-api/src/loci/formats/BytesWrapper.java
@@ -83,20 +83,7 @@ public abstract class BytesWrapper extends ReaderWrapper
   public byte[] openBytes(int no, int x, int y, int w, int h)
     throws FormatException, IOException
   {
-    int ch = getRGBChannelCount();
-    int bpp = FormatTools.getBytesPerPixel(getPixelType());
-    byte[] newBuffer;
-    try {
-      newBuffer = DataTools.allocate(w, h, ch, bpp);
-    }
-    catch (IllegalArgumentException e) {
-      throw new FormatException("Image plane too large. Only 2GB of data can " +
-        "be extracted at one time. You can workaround the problem by opening " +
-        "the plane in tiles; for further details, see: " +
-        "http://www.openmicroscopy.org/site/support/faq/bio-formats/" +
-        "i-see-an-outofmemory-or-negativearraysize-error-message-when-" +
-        "attempting-to-open-an-svs-or-jpeg-2000-file.-what-does-this-mean", e);
-    }
+    byte[] newBuffer = FormatTools.allocatePlane(this, w, h);
     return openBytes(no, newBuffer, x, y, w, h);
   }
 

--- a/components/formats-api/src/loci/formats/FormatReader.java
+++ b/components/formats-api/src/loci/formats/FormatReader.java
@@ -882,20 +882,7 @@ public abstract class FormatReader extends FormatHandler
   public byte[] openBytes(int no, int x, int y, int w, int h)
     throws FormatException, IOException
   {
-    int ch = getRGBChannelCount();
-    int bpp = FormatTools.getBytesPerPixel(getPixelType());
-    byte[] newBuffer;
-    try {
-      newBuffer = DataTools.allocate(w, h, ch, bpp);
-    }
-    catch (IllegalArgumentException e) {
-      throw new FormatException("Image plane too large. Only 2GB of data can " +
-        "be extracted at one time. You can workaround the problem by opening " +
-        "the plane in tiles; for further details, see: " +
-        "http://www.openmicroscopy.org/site/support/faq/bio-formats/" +
-        "i-see-an-outofmemory-or-negativearraysize-error-message-when-" +
-        "attempting-to-open-an-svs-or-jpeg-2000-file.-what-does-this-mean", e);
-    }
+    byte[] newBuffer = FormatTools.allocatePlane(this, w, h);
     return openBytes(no, newBuffer, x, y, w, h);
   }
 

--- a/components/formats-api/src/loci/formats/FormatTools.java
+++ b/components/formats-api/src/loci/formats/FormatTools.java
@@ -38,6 +38,7 @@ import java.util.Properties;
 import java.util.Vector;
 
 import loci.common.Constants;
+import loci.common.DataTools;
 import loci.common.DateTools;
 import loci.common.RandomAccessInputStream;
 import loci.common.ReflectException;
@@ -1218,6 +1219,28 @@ public final class FormatTools {
       }
     }
     return rtn;
+  }
+
+  /**
+   * Allocates a byte array for a plane of the given width and height.
+   * @throws FormatException if the allocated size would be greater than 2 GB
+   */
+  public static byte[] allocatePlane(IFormatReader r, int w, int h) throws FormatException {
+    int ch = r.getRGBChannelCount();
+    int bpp = getBytesPerPixel(r.getPixelType());
+    byte[] newBuffer;
+    try {
+      newBuffer = DataTools.allocate(w, h, ch, bpp);
+    }
+    catch (IllegalArgumentException e) {
+      throw new FormatException("Image plane too large. Only 2GB of data can " +
+        "be extracted at one time. You can workaround the problem by opening " +
+        "the plane in tiles; for further details, see: " +
+        "http://www.openmicroscopy.org/site/support/faq/bio-formats/" +
+        "i-see-an-outofmemory-or-negativearraysize-error-message-when-" +
+        "attempting-to-open-an-svs-or-jpeg-2000-file.-what-does-this-mean", e);
+    }
+    return newBuffer;
   }
 
   // -- Conversion convenience methods --

--- a/components/formats-bsd/src/loci/formats/Colorizer.java
+++ b/components/formats-bsd/src/loci/formats/Colorizer.java
@@ -1,8 +1,6 @@
 /*
  * #%L
- * Bio-Formats Plugins for ImageJ: a collection of ImageJ plugins including the
- * Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions,
- * Data Browser and Stack Slicer.
+ * BSD implementations of Bio-Formats readers and writers
  * %%
  * Copyright (C) 2006 - 2015 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
@@ -48,7 +46,7 @@ public class Colorizer extends BytesWrapper {
   protected LutSource lutSource = null;
 
   // -- Constructor --
-  
+
   public Colorizer(IFormatReader reader) {
       super(reader);
   }
@@ -68,7 +66,10 @@ public class Colorizer extends BytesWrapper {
     throws FormatException, IOException
   {
     buf = reader.openBytes(no, buf, x, y, w, h);
-    return lutSource.applyLut(no, buf, x, y, w, h);
+    if (lutSource != null) {
+      return lutSource.applyLut(no, buf, x, y, w, h);
+    }
+    return buf;
   }
 
   @Override

--- a/components/formats-bsd/src/loci/formats/Colorizer.java
+++ b/components/formats-bsd/src/loci/formats/Colorizer.java
@@ -83,6 +83,16 @@ public class Colorizer extends BytesWrapper {
   }
 
   @Override
+  public boolean isRGB() {
+    return lutSource == null ? super.isRGB() : true;
+  }
+
+  @Override
+  public boolean isInterleaved() {
+    return lutSource == null ? super.isInterleaved() : true;
+  }
+
+  @Override
   public byte[][] get8BitLookupTable() throws FormatException, IOException {
     return super.get8BitLookupTable();
   }

--- a/components/formats-common/src/loci/common/lut/ij/ImageJLutSource.java
+++ b/components/formats-common/src/loci/common/lut/ij/ImageJLutSource.java
@@ -34,6 +34,8 @@ package loci.common.lut.ij;
 
 import loci.common.lut.AbstractLutSource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link LutSource} which makes use of the {@link loci.commons.lut.ij.LutLoader}
@@ -43,10 +45,14 @@ import loci.common.lut.AbstractLutSource;
  */
 public class ImageJLutSource extends AbstractLutSource {
 
+    /** Logger for this class. */
+    private static final Logger LOGGER =
+      LoggerFactory.getLogger(ImageJLutSource.class);
+
     private final byte[] reds;
     private final byte[] greens;
     private final byte[] blues;
-    
+
     public ImageJLutSource(String ijArg) {
         LutLoader loader = new LutLoader();
         loader.run(ijArg);
@@ -83,12 +89,12 @@ public class ImageJLutSource extends AbstractLutSource {
       byte[][] b = rtn; // ImageTools.indexedToRGB(new byte[][]{reds, greens, blues}, buf);
       // non-interleaved
       if (false) {
-        System.out.println("b.length=" + b.length);
-        System.out.println("buf.length=" + buf.length);
-        System.out.println("lut.length=" + lut.length);
-        System.out.println("lut[0].length=" + lut[0].length);
+        LOGGER.info("b.length={}", b.length);
+        LOGGER.info("buf.length={}", buf.length);
+        LOGGER.info("lut.length={}", lut.length);
+        LOGGER.info("lut[0].length={}", lut[0].length);
         for (int i=0; i<b.length; i++) {
-          System.out.println("b[" + i + "]=" + b[i].length);
+          LOGGER.info("b[{}] = {}", i, b[i].length);
           System.arraycopy(b[i], 0, buf, i*b[i].length, b[i].length);
         }
         return buf;
@@ -104,5 +110,4 @@ public class ImageJLutSource extends AbstractLutSource {
       }
       return buf;
     }
-
 }

--- a/components/formats-common/src/loci/common/lut/ij/ImageJLutSource.java
+++ b/components/formats-common/src/loci/common/lut/ij/ImageJLutSource.java
@@ -71,43 +71,20 @@ public class ImageJLutSource extends AbstractLutSource {
         this.blues = blues;
     }
 
+    @Override
     public byte[] applyLut(int no, byte[] buf, int x, int y, int w, int h) {
-
-      // FIXME The following is non-functional and only for testing purposes.
 
       // copied from ImageTools which is in bsd
       byte[][] lut = new byte[][] { reds, greens, blues };
-      byte[][] rtn = new byte[lut.length][buf.length];
+      byte[] rtn = new byte[lut.length * buf.length];
 
+      // currently assumes 8-bit data only
       for (int i=0; i<buf.length; i++) {
         for (int j=0; j<lut.length; j++) {
-          rtn[j][i] = lut[j][buf[i] & 0xff];
+          rtn[i * lut.length + j] = lut[j][buf[i] & 0xff];
         }
       }
 
-      // partial copy from ChannelFiller. Needs refactoring.
-      byte[][] b = rtn; // ImageTools.indexedToRGB(new byte[][]{reds, greens, blues}, buf);
-      // non-interleaved
-      if (false) {
-        LOGGER.info("b.length={}", b.length);
-        LOGGER.info("buf.length={}", buf.length);
-        LOGGER.info("lut.length={}", lut.length);
-        LOGGER.info("lut[0].length={}", lut[0].length);
-        for (int i=0; i<b.length; i++) {
-          LOGGER.info("b[{}] = {}", i, b[i].length);
-          System.arraycopy(b[i], 0, buf, i*b[i].length, b[i].length);
-        }
-        return buf;
-      }
-
-      // interleaved
-      int pt = 0;
-      for (int i=0; i<b[0].length; i++) {
-        //for (int j=0; j<b.length; j++) {
-        for (int j=0; j<1; j++) { // FIXME
-          buf[pt++] = b[j][i];
-        }
-      }
-      return buf;
+      return rtn;
     }
 }

--- a/components/formats-common/src/loci/common/lut/ij/LUT.java
+++ b/components/formats-common/src/loci/common/lut/ij/LUT.java
@@ -6,9 +6,6 @@ package loci.common.lut.ij;
 
 import java.awt.Color;
 import java.awt.image.IndexColorModel;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 
 	/** This is an indexed color model that allows an
 		lower and upper bound to be specified. */

--- a/components/formats-common/src/loci/common/lut/ij/LUT.java
+++ b/components/formats-common/src/loci/common/lut/ij/LUT.java
@@ -14,36 +14,36 @@ import java.util.Locale;
 		lower and upper bound to be specified. */
     class LUT extends IndexColorModel implements Cloneable {
         public double min, max;
-	
+
     /** Constructs a LUT from red, green and blue byte arrays, which must have a length of 256. */
     public LUT(byte r[], byte g[], byte b[]) {
     	this(8, 256, r, g, b);
 	}
-	
+
     /** Constructs a LUT from red, green and blue byte arrays, where 'bits' 
     	must be 8 and 'size' must be less than or equal to 256. */
     public LUT(int bits, int size, byte r[], byte g[], byte b[]) {
     	super(bits, size, r, g, b);
 	}
-	
+
 	public LUT(IndexColorModel cm, double min, double max) {
 		super(8, cm.getMapSize(), getReds(cm), getGreens(cm), getBlues(cm));
 		this.min = min;
 		this.max = max;
 	}
-	
+
 	static byte[] getReds(IndexColorModel cm) {
 		byte[] reds=new byte[256]; cm.getReds(reds); return reds;
 	}
-	
+
 	static byte[] getGreens(IndexColorModel cm) {
 		byte[] greens=new byte[256]; cm.getGreens(greens); return greens;
 	}
-	
+
 	static byte[] getBlues(IndexColorModel cm) {
 		byte[] blues=new byte[256]; cm.getBlues(blues); return blues;
 	}
-	
+
 	public byte[] getBytes() {
 		int size = getMapSize();
 		if (size!=256) return null;
@@ -53,17 +53,17 @@ import java.util.Locale;
 		for (int i=0; i<256; i++) bytes[512+i] = (byte)getBlue(i);
 		return bytes;
 	}
-	
+
 	public LUT createInvertedLut() {
 		int mapSize = getMapSize();
 		byte[] reds = new byte[mapSize];
 		byte[] greens = new byte[mapSize];
-		byte[] blues = new byte[mapSize];	
+		byte[] blues = new byte[mapSize];
 		byte[] reds2 = new byte[mapSize];
 		byte[] greens2 = new byte[mapSize];
-		byte[] blues2 = new byte[mapSize];	
-		getReds(reds); 
-		getGreens(greens); 
+		byte[] blues2 = new byte[mapSize];
+		getReds(reds);
+		getGreens(greens);
 		getBlues(blues);
 		for (int i=0; i<mapSize; i++) {
 			reds2[i] = (byte)(reds[mapSize-i-1]&255);
@@ -72,7 +72,7 @@ import java.util.Locale;
 		}
 		return new LUT(8, mapSize, reds2, greens2, blues2);
 	}
-	
+
 	/** Creates a color LUT from a Color. */
 	public static LUT createLutFromColor(Color color) {
 		byte[] rLut = new byte[256];
@@ -96,10 +96,11 @@ import java.util.Locale;
 		try {return super.clone();}
 		catch (CloneNotSupportedException e) {return null;}
 	}
-	
+
 	public  String toString() {
 		return "rgb[0]="+colorToString(new Color(getRGB(0)))+", rgb[255]="
-			+colorToString(new Color(getRGB(255)))+", min="+d2s(min,4)+", max="+d2s(max,4);
+			+colorToString(new Color(getRGB(255)))+", min="+String.format("%.4f", min)+
+      ", max="+String.format("%.4", max);
 	}
 
 	// Copied from ij.plugins.Colors
@@ -130,83 +131,5 @@ import java.util.Locale;
 		else if (hex.equals("ff00ff")) color = "magenta";
 		return color;
 	}
-	
 
-	// Copied from IJ
-    /** Converts a number to a rounded formatted string.
-        The 'decimalPlaces' argument specifies the number of
-        digits to the right of the decimal point (0-9). Uses
-        scientific notation if 'decimalPlaces is negative. */
-    public static String d2s(double n, int decimalPlaces) {
-        if (Double.isNaN(n)||Double.isInfinite(n))
-            return ""+n;
-        if (n==Float.MAX_VALUE) // divide by 0 in FloatProcessor
-            return "3.4e38";
-        double np = n;
-
-        // TODO: Use these statically?
-        DecimalFormat[] df = null;
-        DecimalFormat[] sf = null;
-        DecimalFormatSymbols dfs = null;
-
-        if (n<0.0) np = -n;
-        if (decimalPlaces<0) {
-            decimalPlaces = -decimalPlaces;
-            if (decimalPlaces>9) decimalPlaces=9;
-            if (sf==null) {
-                if (dfs==null)
-                    dfs = new DecimalFormatSymbols(Locale.US);
-                sf = new DecimalFormat[10];
-                sf[1] = new DecimalFormat("0.0E0",dfs);
-                sf[2] = new DecimalFormat("0.00E0",dfs);
-                sf[3] = new DecimalFormat("0.000E0",dfs);
-                sf[4] = new DecimalFormat("0.0000E0",dfs);
-                sf[5] = new DecimalFormat("0.00000E0",dfs);
-                sf[6] = new DecimalFormat("0.000000E0",dfs);
-                sf[7] = new DecimalFormat("0.0000000E0",dfs);
-                sf[8] = new DecimalFormat("0.00000000E0",dfs);
-                sf[9] = new DecimalFormat("0.000000000E0",dfs);
-            }
-            return sf[decimalPlaces].format(n); // use scientific notation
-        }
-        if (decimalPlaces<0) decimalPlaces = 0;
-        if (decimalPlaces>9) decimalPlaces = 9;
-        if (df==null) {
-            dfs = new DecimalFormatSymbols(Locale.US);
-            df = new DecimalFormat[10];
-            df[0] = new DecimalFormat("0", dfs);
-            df[1] = new DecimalFormat("0.0", dfs);
-            df[2] = new DecimalFormat("0.00", dfs);
-            df[3] = new DecimalFormat("0.000", dfs);
-            df[4] = new DecimalFormat("0.0000", dfs);
-            df[5] = new DecimalFormat("0.00000", dfs);
-            df[6] = new DecimalFormat("0.000000", dfs);
-            df[7] = new DecimalFormat("0.0000000", dfs);
-            df[8] = new DecimalFormat("0.00000000", dfs);
-            df[9] = new DecimalFormat("0.000000000", dfs);
-        }
-        return df[decimalPlaces].format(n);
-    }
-
-    // Copied from IJ
-    /** Converts a number to a rounded formatted string.
-    * The 'significantDigits' argument specifies the minimum number
-    * of significant digits, which is also the preferred number of
-    * digits behind the decimal. Fewer decimals are shown if the 
-    * number would have more than 'maxDigits'.
-    * Exponential notation is used if more than 'maxDigits' would be needed.
-    */
-    public static String d2s(double x, int significantDigits, int maxDigits) {
-        double log10 = Math.log10(Math.abs(x));
-        double roundErrorAtMax = 0.223*Math.pow(10, -maxDigits);
-        int magnitude = (int)Math.ceil(log10+roundErrorAtMax);
-        int decimals = x==0 ? 0 : maxDigits - magnitude;
-        if (decimals<0 || magnitude<significantDigits+1-maxDigits)
-            return d2s(x, -significantDigits); // exp notation for large and small numbers
-        else {
-            if (decimals>significantDigits)
-                decimals = Math.max(significantDigits, decimals-maxDigits+significantDigits);
-            return d2s(x, decimals);
-        }
-    }
 }

--- a/components/formats-common/src/loci/common/lut/ij/LutLoader.java
+++ b/components/formats-common/src/loci/common/lut/ij/LutLoader.java
@@ -17,95 +17,96 @@ import java.io.InputStream;
 	passed to the run() method. */
 class LutLoader {
 
-    private static class FileInfo {
-        int lutSize;
-        byte[] reds;
-        byte[] greens;
-        byte[] blues;
-        String fileName;
-    }
-
-	private String defaultDirectory = null;
-
-	private FileInfo fi;
+  private int lutSize;
+  private byte[] reds;
+  private byte[] greens;
+  private byte[] blues;
+  private String fileName;
 
 	/** If 'arg'="", displays a file open dialog and opens the specified
 		LUT. If 'arg' is a path, opens the LUT specified by the path. If
 		'arg'="fire", "ice", etc., uses a method to generate the LUT. */
 	public void run(String arg) {
-		fi = new FileInfo();
-		fi.reds = new byte[256];
-		fi.greens = new byte[256];
-		fi.blues = new byte[256];
-		fi.lutSize = 256;
+		reds = new byte[256];
+		greens = new byte[256];
+		blues = new byte[256];
+		lutSize = 256;
 		int nColors = 0;
 
-		if (arg.equals("fire"))
-			nColors = fire(fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("grays"))
-			nColors = grays(fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("ice"))
-			nColors = ice(fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("spectrum"))
-			nColors = spectrum(fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("3-3-2 RGB"))
-			nColors = rgb332(fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("red"))
-			nColors = primaryColor(4, fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("green"))
-			nColors = primaryColor(2, fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("blue"))
-			nColors = primaryColor(1, fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("cyan"))
-			nColors = primaryColor(3, fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("magenta"))
-			nColors = primaryColor(5, fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("yellow"))
-			nColors = primaryColor(6, fi.reds, fi.greens, fi.blues);
-		else if (arg.equals("redgreen"))
-			nColors = redGreen(fi.reds, fi.greens, fi.blues);
-		fi.lutSize = nColors;
-		if (nColors>0) {
-			if (nColors<256)
-				interpolate(fi.reds, fi.greens, fi.blues, nColors);
-			fi.fileName = arg;
-			return;
+		if (arg.equals("fire")) {
+			nColors = fire();
+    }
+		else if (arg.equals("grays")) {
+			nColors = grays();
+    }
+		else if (arg.equals("ice")) {
+			nColors = ice();
+    }
+		else if (arg.equals("spectrum")) {
+			nColors = spectrum();
+    }
+		else if (arg.equals("3-3-2 RGB")) {
+			nColors = rgb332();
+    }
+		else if (arg.equals("red")) {
+			nColors = primaryColor(4);
+    }
+		else if (arg.equals("green")) {
+			nColors = primaryColor(2);
+    }
+		else if (arg.equals("blue")) {
+			nColors = primaryColor(1);
+    }
+		else if (arg.equals("cyan")) {
+			nColors = primaryColor(3);
+    }
+		else if (arg.equals("magenta")) {
+			nColors = primaryColor(5);
+    }
+		else if (arg.equals("yellow")) {
+			nColors = primaryColor(6);
+    }
+		else if (arg.equals("redgreen")) {
+			nColors = redGreen();
+    }
+		lutSize = nColors;
+		if (nColors > 0) {
+			if (nColors < 256) {
+				interpolate(nColors);
+      }
+			fileName = arg;
 		}
 	}
 
 	public int getLutSize() {
-	    return fi.lutSize;
+	    return lutSize;
 	}
 
 	public byte[] getReds() {
-	    return fi.reds;
+	    return reds;
 	}
 
 	public byte[] getGreens() {
-	    return fi.greens;
+	    return greens;
 	}
 
 	public byte[] getBlues() {
-	    return fi.blues;
+	    return blues;
 	}
 
 	// Remove void showLut(FileInfo, boolean)
 
 	// Removed void invertLut
 
-	int fire(byte[] reds, byte[] greens, byte[] blues) {
+	int fire() {
 		int[] r = {0,0,1,25,49,73,98,122,146,162,173,184,195,207,217,229,240,252,255,255,255,255,255,255,255,255,255,255,255,255,255,255};
 		int[] g = {0,0,0,0,0,0,0,0,0,0,0,0,0,14,35,57,79,101,117,133,147,161,175,190,205,219,234,248,255,255,255,255};
 		int[] b = {0,61,96,130,165,192,220,227,210,181,151,122,93,64,35,5,0,0,0,0,0,0,0,0,0,0,0,35,98,160,223,255};
-		for (int i=0; i<r.length; i++) {
-			reds[i] = (byte)r[i];
-			greens[i] = (byte)g[i];
-			blues[i] = (byte)b[i];
-		}
+    copyIntArrays(r, g, b);
 		return r.length;
 	}
 
-	int grays(byte[] reds, byte[] greens, byte[] blues) {
+	int grays() {
 		for (int i=0; i<256; i++) {
 			reds[i] = (byte)i;
 			greens[i] = (byte)i;
@@ -114,31 +115,33 @@ class LutLoader {
 		return 256;
 	}
 
-	int primaryColor(int color, byte[] reds, byte[] greens, byte[] blues) {
+	int primaryColor(int color) {
+    boolean red = (color & 4) != 0;
+    boolean green = (color & 2) != 0;
+    boolean blue = (color & 1) != 0;
 		for (int i=0; i<256; i++) {
-			if ((color&4)!=0)
-				reds[i] = (byte)i;
-			if ((color&2)!=0)
-				greens[i] = (byte)i;
-			if ((color&1)!=0)
-				blues[i] = (byte)i;
+      if (red) {
+				reds[i] = (byte) i;
+      }
+      if (green) {
+				greens[i] = (byte) i;
+      }
+      if (blue) {
+				blues[i] = (byte) i;
+      }
 		}
 		return 256;
 	}
 
-	int ice(byte[] reds, byte[] greens, byte[] blues) {
+	int ice() {
 		int[] r = {0,0,0,0,0,0,19,29,50,48,79,112,134,158,186,201,217,229,242,250,250,250,250,251,250,250,250,250,251,251,243,230};
 		int[] g = {156,165,176,184,190,196,193,184,171,162,146,125,107,93,81,87,92,97,95,93,93,90,85,69,64,54,47,35,19,0,4,0};
 		int[] b = {140,147,158,166,170,176,209,220,234,225,236,246,250,251,250,250,245,230,230,222,202,180,163,142,123,114,106,94,84,64,26,27};
-		for (int i=0; i<r.length; i++) {
-			reds[i] = (byte)r[i];
-			greens[i] = (byte)g[i];
-			blues[i] = (byte)b[i];
-		}
+    copyIntArrays(r, g, b);
 		return r.length;
 	}
 
-	int spectrum(byte[] reds, byte[] greens, byte[] blues) {
+	int spectrum() {
 		Color c;
 		for (int i=0; i<256; i++) {
 			c = Color.getHSBColor(i/255f, 1f, 1f);
@@ -149,7 +152,7 @@ class LutLoader {
 		return 256;
 	}
 
-	int rgb332(byte[] reds, byte[] greens, byte[] blues) {
+	int rgb332() {
 		for (int i=0; i<256; i++) {
 			reds[i] = (byte)(i&0xe0);
 			greens[i] = (byte)((i<<3)&0xe0);
@@ -158,7 +161,7 @@ class LutLoader {
 		return 256;
 	}
 
-	int redGreen(byte[] reds, byte[] greens, byte[] blues) {
+	int redGreen() {
 		for (int i=0; i<128; i++) {
 			reds[i] = (byte)(i*2);
 			greens[i] = (byte)0;
@@ -172,7 +175,7 @@ class LutLoader {
 		return 256;
 	}
 
-	void interpolate(byte[] reds, byte[] greens, byte[] blues, int nColors) {
+	void interpolate(int nColors) {
 		byte[] r = new byte[nColors];
 		byte[] g = new byte[nColors];
 		byte[] b = new byte[nColors];
@@ -187,12 +190,19 @@ class LutLoader {
 			i2 = i1+1;
 			if (i2==nColors) i2 = nColors-1;
 			fraction = i*scale - i1;
-			//IJ.write(i+" "+i1+" "+i2+" "+fraction);
 			reds[i] = (byte)((1.0-fraction)*(r[i1]&255) + fraction*(r[i2]&255));
 			greens[i] = (byte)((1.0-fraction)*(g[i1]&255) + fraction*(g[i2]&255));
 			blues[i] = (byte)((1.0-fraction)*(b[i1]&255) + fraction*(b[i2]&255));
 		}
 	}
+
+  void copyIntArrays(int[] r, int[] g, int[] b) {
+    for (int i=0; i<r.length; i++) {
+      reds[i] = (byte) r[i];
+      greens[i] = (byte) g[i];
+      blues[i] = (byte) b[i];
+    }
+  }
 
 	// Removed: boolean openLut(String)
 	// See comment on openTextLut
@@ -219,14 +229,14 @@ class LutLoader {
 		and returns it as an IndexColorModel. Since 1.43t. */
 	public static IndexColorModel open(InputStream stream) throws IOException {
 		DataInputStream f = new DataInputStream(stream);
-		byte[] reds = new byte[256];
-		byte[] greens = new byte[256];
-		byte[] blues = new byte[256];
-		f.read(reds, 0, 256);
-		f.read(greens, 0, 256);
-		f.read(blues, 0, 256);
+		byte[] r = new byte[256];
+		byte[] g = new byte[256];
+		byte[] b = new byte[256];
+		f.read(r, 0, 256);
+		f.read(g, 0, 256);
+		f.read(b, 0, 256);
 		f.close();
-		return new IndexColorModel(8, 256, reds, greens, blues);
+		return new IndexColorModel(8, 256, r, g, b);
 	}
 
 	// Removed ByteProcessor createImage(IndexColorModel)


### PR DESCRIPTION
This does some cleanup, and makes it so that `bfconvert -colorize LUT_NAME input output` on an 8-bit input file works as expected.

The assumption is made that applyLut will always output RGB interleaved data; what the base reader expects isn't really relevant since Colorizer can (and now does) override the RGB etc. settings.

As mentioned previously, applyLut doesn't have enough context to deal with >8-bit data at the moment.  While >8-bit data shouldn't throw an exception, it will look weird.  I also haven't yet done anything about source data that is already RGB, so that is also likely to look weird with a LUT applied.
