### PR TITLE
Set the Image-Instrument graph

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
+++ b/components/formats-gpl/src/loci/formats/in/MetamorphReader.java
@@ -790,12 +790,9 @@ public class MetamorphReader extends BaseTiffReader {
       store.setPlateColumnNamingConvention(NamingConvention.NUMBER, 0);
     }
 
-    instrumentID = null;
-    if (false) { // METADATA-ONLY
-      store.setInstrumentID(instrumentID, 0);
-      store.setDetectorID(detectorID, 0, 0);
-      store.setDetectorType(getDetectorType("Other"), 0, 0);
-    }
+    store.setInstrumentID(instrumentID, 0);
+    store.setDetectorID(detectorID, 0, 0);
+    store.setDetectorType(getDetectorType("Other"), 0, 0);
 
     for (int i=0; i<getSeriesCount(); i++) {
       setSeries(i);
@@ -815,8 +812,7 @@ public class MetamorphReader extends BaseTiffReader {
         store.setWellSampleIndex(new NonNegativeInteger(i), 0, i, 0);
       }
 
-      // METADATA-ONLY
-      // store.setImageInstrumentRef(instrumentID, i);
+      store.setImageInstrumentRef(instrumentID, i);
 
       String comment = getFirstComment(i);
       if (i == 0 || !isHCS) {


### PR DESCRIPTION
Unifies the behavior of `metadata54` with https://github.com/openmicroscopy/bioformats/pull/2750

Without this PR, CellWorkxReader.initFile fails as it expects an instrument to be defined

```
sbesson@lifesci-62634:bioformats (metadata54) $ ./tools/showinf -nopix ~/Desktop/data_repo/TimePoint_1/plate\ 11001.HTD 
*** A new stable version is available. ***
*** Install the new version using:     ***
***   'upgradechecker -install'        ***
Checking file format [CellWorx]
Initializing reader
CellWorxReader initializing /Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001.HTD
Reading IFDs
Populating metadata
Populating OME metadata
Exception in thread "main" java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:653)
	at java.util.ArrayList.get(ArrayList.java:429)
	at ome.xml.model.OME.getInstrument(OME.java:665)
	at loci.formats.in.CellWorxReader.initFile(CellWorxReader.java:412)
	at loci.formats.FormatReader.setId(FormatReader.java:1397)
	at loci.formats.ImageReader.setId(ImageReader.java:845)
	at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650)
	at loci.formats.tools.ImageInfo.testRead(ImageInfo.java:1024)
	at loci.formats.tools.ImageInfo.main(ImageInfo.java:1110)
```

With this commit included

```
sbesson@lifesci-62634:bioformats (metadata54) $ ./tools/showinf -nopix ~/Desktop/data_repo/TimePoint_1/plate\ 11001.HTD 
*** A new stable version is available. ***
*** Install the new version using:     ***
***   'upgradechecker -install'        ***
Checking file format [CellWorx]
Initializing reader
CellWorxReader initializing /Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001.HTD
Reading IFDs
Populating metadata
Populating OME metadata
Initialization took 0.404s

Reading core metadata
filename = /Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001.HTD
Used files:
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001.HTD
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s1_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s1_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s2_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s2_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s3_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s3_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s4_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s4_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s5_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s5_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s6_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s6_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s7_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s7_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s8_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s8_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s9_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s9_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s10_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s10_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s11_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s11_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s12_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s12_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s13_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s13_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s14_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s14_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s15_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s15_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s16_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A01_s16_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s1_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s1_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s2_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s2_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s3_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s3_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s4_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s4_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s5_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s5_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s6_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s6_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s7_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s7_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s8_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s8_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s9_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s9_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s10_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s10_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s11_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s11_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s12_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s12_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s13_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s13_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s14_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s14_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s15_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s15_w2.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s16_w1.tif
	/Users/sbesson/Desktop/data_repo/TimePoint_1/plate 11001_A02_s16_w2.tif
```